### PR TITLE
Implement admin editing route

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ Konverzace se ukládají jako JSONL:
 ---
 
 Webové rozhraní je dostupné na adrese `/` po spuštění serveru.
+
+## 🔐 Admin rozhraní
+Konfiguraci v `config/config.json` lze upravit na adrese `/admin`.
+Výchozí heslo je `Kostal@2025` a můžete jej změnit pomocí proměnné
+prostředí `ADMIN_PASS`. Rozhraní umožňuje měnit API klíče i model a je
+určeno pouze pro interní použití.

--- a/static/admin.html
+++ b/static/admin.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin</title>
+</head>
+<body>
+<h1>Admin Config Editor</h1>
+<form id="configForm">
+    Password: <input type="password" id="password"><br>
+    <textarea id="config" rows="20" cols="80"></textarea><br>
+    <button type="submit">Save</button>
+</form>
+<pre id="status"></pre>
+<script>
+async function loadConfig(pw) {
+    const res = await fetch('/admin/config?password=' + encodeURIComponent(pw));
+    if (res.ok) {
+        const data = await res.json();
+        document.getElementById('config').value = data.config;
+    } else {
+        document.getElementById('status').textContent = 'Unauthorized';
+    }
+}
+
+document.getElementById('configForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const password = document.getElementById('password').value;
+    const config = document.getElementById('config').value;
+    const res = await fetch('/admin/config', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({password, config})
+    });
+    const data = await res.json();
+    document.getElementById('status').textContent = JSON.stringify(data);
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const pw = prompt('Admin password:');
+    if (pw) {
+        document.getElementById('password').value = pw;
+        loadConfig(pw);
+    }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `/admin` route with password gate and editing API config
- add admin UI template
- document `/admin` usage and default password

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6863ebe170e08322af83bdc0f26f1751