### PR TITLE
Sanitize memory user names

### DIFF
--- a/app/memory.py
+++ b/app/memory.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from datetime import datetime
 
 MEMORY_ROOT = os.path.join(os.path.dirname(__file__), '..', 'memory')
@@ -10,6 +11,8 @@ KNOWLEDGE_LOG = os.path.join(MEMORY_ROOT, 'knowledge_additions.jsonl')
 
 def save_interaction(user: str, user_message: str, bot_message: str) -> None:
     """Append a conversation entry for given user."""
+    # Sanitize user string to avoid directory traversal
+    user = re.sub(r"[^A-Za-z0-9_]+", "", user)
     user_dir = os.path.join(MEMORY_ROOT, user)
     os.makedirs(user_dir, exist_ok=True)
     log_file = os.path.join(user_dir, 'private.jsonl')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,25 @@
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+
+from app import memory
+
+
+def test_save_interaction_sanitizes_user(tmp_path, monkeypatch):
+    root = tmp_path / "mem"
+    monkeypatch.setattr(memory, "MEMORY_ROOT", str(root))
+    monkeypatch.setattr(memory, "KNOWLEDGE_LOG", os.path.join(str(root), "knowledge_additions.jsonl"))
+
+    user = "bob/../../evil"
+    memory.save_interaction(user, "hi", "hello")
+
+    sanitized = re.sub(r"[^A-Za-z0-9_]+", "", user)
+    expected_file = root / sanitized / "private.jsonl"
+    assert expected_file.is_file()
+    # Ensure the file is within the configured memory root
+    assert root.resolve() in expected_file.resolve().parents


### PR DESCRIPTION
## Summary
- sanitize usernames in memory storage to avoid unsafe characters
- add tests to ensure sanitization and paths stay within memory root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863ed1f35288322ac44ad1b60e5ea6a