### PR TITLE
Log knowledge comment

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -71,7 +71,7 @@ def add_knowledge():
         return jsonify({'error': 'Provide text or file'}), 400
     try:
         knowledge.add_entry(title, comment, text=text, file=file_obj)
-        memory.log_knowledge_addition(title)
+        memory.log_knowledge_addition(title, comment)
     except Exception as exc:
         return jsonify({'error': str(exc)}), 500
     return jsonify({'status': 'ok'})

--- a/app/memory.py
+++ b/app/memory.py
@@ -25,12 +25,13 @@ def save_interaction(user: str, user_message: str, bot_message: str) -> None:
         fh.write(json.dumps(entry, ensure_ascii=False) + '\n')
 
 
-def log_knowledge_addition(title: str) -> None:
+def log_knowledge_addition(title: str, comment: str) -> None:
     """Log a knowledge entry creation."""
     os.makedirs(MEMORY_ROOT, exist_ok=True)
     entry = {
         'timestamp': datetime.utcnow().isoformat(),
         'title': title,
+        'comment': comment,
     }
     with open(KNOWLEDGE_LOG, 'a', encoding='utf-8') as fh:
         fh.write(json.dumps(entry, ensure_ascii=False) + '\n')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import json
 from pathlib import Path
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -23,3 +24,18 @@ def test_save_interaction_sanitizes_user(tmp_path, monkeypatch):
     assert expected_file.is_file()
     # Ensure the file is within the configured memory root
     assert root.resolve() in expected_file.resolve().parents
+
+
+def test_log_knowledge_addition_writes_comment(tmp_path, monkeypatch):
+    root = tmp_path / "mem"
+    log_path = root / "knowledge_additions.jsonl"
+    monkeypatch.setattr(memory, "MEMORY_ROOT", str(root))
+    monkeypatch.setattr(memory, "KNOWLEDGE_LOG", str(log_path))
+
+    memory.log_knowledge_addition("My Title", "Some comment")
+
+    assert log_path.is_file()
+    line = log_path.read_text(encoding="utf-8").strip()
+    entry = json.loads(line)
+    assert entry["title"] == "My Title"
+    assert entry["comment"] == "Some comment"


### PR DESCRIPTION
## Summary
- expand `memory.log_knowledge_addition` to include comment data
- log the comment in `main.add_knowledge`
- test comment logging in `knowledge_additions.jsonl`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863f0845ca08322b74449d2629a6ba2