### PR TITLE
Implement load_interactions in memory

### DIFF
--- a/app/memory.py
+++ b/app/memory.py
@@ -25,6 +25,24 @@ def save_interaction(user: str, user_message: str, bot_message: str) -> None:
         fh.write(json.dumps(entry, ensure_ascii=False) + '\n')
 
 
+def load_interactions(user: str) -> list:
+    """Return list of conversation entries for given user."""
+    # Sanitize user string to avoid directory traversal
+    user = re.sub(r"[^A-Za-z0-9_]+", "", user)
+    log_file = os.path.join(MEMORY_ROOT, user, 'private.jsonl')
+    if not os.path.exists(log_file):
+        return []
+
+    entries = []
+    with open(log_file, 'r', encoding='utf-8') as fh:
+        for line in fh:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
 def log_knowledge_addition(title: str, comment: str) -> None:
     """Log a knowledge entry creation."""
     os.makedirs(MEMORY_ROOT, exist_ok=True)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -39,3 +39,35 @@ def test_log_knowledge_addition_writes_comment(tmp_path, monkeypatch):
     entry = json.loads(line)
     assert entry["title"] == "My Title"
     assert entry["comment"] == "Some comment"
+
+
+def test_load_interactions_parses_entries(tmp_path, monkeypatch):
+    root = tmp_path / "mem"
+    monkeypatch.setattr(memory, "MEMORY_ROOT", str(root))
+    monkeypatch.setattr(memory, "KNOWLEDGE_LOG", os.path.join(str(root), "knowledge_additions.jsonl"))
+
+    user = "alice/../../secret"
+    sanitized = re.sub(r"[^A-Za-z0-9_]+", "", user)
+    log_path = root / sanitized
+    log_path.mkdir(parents=True)
+    file = log_path / "private.jsonl"
+    entries = [
+        {"timestamp": "t1", "user": "hi", "bot": "hello"},
+        {"timestamp": "t2", "user": "hey", "bot": "hi"},
+    ]
+    with open(file, "w", encoding="utf-8") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+        fh.write("bad json\n")
+
+    loaded = memory.load_interactions(user)
+    assert loaded == entries
+
+
+def test_load_interactions_missing_file(tmp_path, monkeypatch):
+    root = tmp_path / "mem"
+    monkeypatch.setattr(memory, "MEMORY_ROOT", str(root))
+    monkeypatch.setattr(memory, "KNOWLEDGE_LOG", os.path.join(str(root), "knowledge_additions.jsonl"))
+
+    loaded = memory.load_interactions("nosuchuser")
+    assert loaded == []


### PR DESCRIPTION
## Summary
- implement `load_interactions` for reading user's conversation log
- return parsed json entries while sanitizing user input
- test behaviour of the new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864cdd1f734832280824b9979f9bcf5