### PR TITLE
Update README admin password guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ Webové rozhraní je dostupné na adrese `/` po spuštění serveru.
 
 ## 🔐 Admin rozhraní
 Konfiguraci v `config/config.json` lze upravit na adrese `/admin`.
-Výchozí heslo je `Kostal@2025` a můžete jej změnit pomocí proměnné
-prostředí `ADMIN_PASS`. Pro ověření se používá HTTP Basic Auth nebo
-odeslání hesla v těle POST požadavku. Rozhraní umožňuje měnit API klíče
-i model a je určeno pouze pro interní použití.
-Příklad načtení konfigurace pomocí `curl`:
+Heslo pro přístup se nastavuje proměnnou prostředí `ADMIN_PASS`
+(výchozí hodnota `Kostal@2025` je určena jen pro lokální testování).
+Pro ověření se používá HTTP Basic Auth nebo odeslání hesla v těle POST
+požadavku. Rozhraní umožňuje měnit API klíče i model a je určeno pouze
+pro interní použití. Příklad načtení konfigurace pomocí `curl`:
 ```bash
-curl -u admin:Kostal@2025 http://localhost:5000/admin/config
+curl -u admin:$ADMIN_PASS http://localhost:5000/admin/config
 ```


### PR DESCRIPTION
## Summary
- clarify that `ADMIN_PASS` must be set for any deployment
- remove plain-text password example and show usage with an environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864de12ed588322ae94be7c01916c46