### PR TITLE
Add portable Python detection to scripts

### DIFF
--- a/scripts/update_instance.sh
+++ b/scripts/update_instance.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+# Detect available Python interpreter
+PYTHON=$(command -v python3 || command -v python || command -v py)
+if [ -z "$PYTHON" ]; then
+    echo "Python interpreter not found." >&2
+    exit 1
+fi
+
 # Determine the directory this script lives in and switch to the
 # repository root so relative paths work regardless of where the
 # script is invoked from.
@@ -35,9 +42,9 @@ fi
 git pull
 
 # Install dependencies
-python3 -m pip install -r requirements.txt
+"$PYTHON" -m pip install -r requirements.txt
 
 # Restart Flask server
-nohup python3 app/main.py > flask.log 2>&1 &
+nohup "$PYTHON" app/main.py > flask.log 2>&1 &
 
 echo "Server restarted."

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+# Detect available Python interpreter
+PYTHON=$(command -v python3 || command -v python || command -v py)
+if [ -z "$PYTHON" ]; then
+    echo "Python interpreter not found." >&2
+    exit 1
+fi
+
 # Determine the directory this script lives in and switch to the
 # repository root so relative paths work regardless of where the
 # script is invoked from.
@@ -24,6 +31,6 @@ if [ -n "$pids" ]; then
 fi
 
 # Start the Flask server
-nohup python3 app/main.py > flask.log 2>&1 &
+nohup "$PYTHON" app/main.py > flask.log 2>&1 &
 
 echo "Server started."


### PR DESCRIPTION
## Summary
- detect a usable Python interpreter before running commands
- use the detected Python instead of hardcoded `python3`

## Testing
- `pytest -q`
- `shellcheck start.sh scripts/update_instance.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864f28c151c8322be69734697e5e9d6