### PR TITLE
Require ADMIN_PASS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ jarvik-kostal/
 ## 🚀 Spuštění
 ```bash
 export FLASK_APP=app/main.py
+export ADMIN_PASS=mojeheslo
 flask run
 ```
-Nebo jednoduše:
+Nebo jednoduše (nezapomeň nastavit heslo):
 ```bash
+export ADMIN_PASS=mojeheslo
 python3 app/main.py
 ```
 
@@ -134,8 +136,8 @@ Webové rozhraní je dostupné na adrese `/` po spuštění serveru.
 
 ## 🔐 Admin rozhraní
 Konfiguraci v `config/config.json` lze upravit na adrese `/admin`.
-Heslo pro přístup se nastavuje proměnnou prostředí `ADMIN_PASS`
-(výchozí hodnota `Kostal@2025` je určena jen pro lokální testování).
+Heslo pro přístup se nastavuje proměnnou prostředí `ADMIN_PASS` a
+server se nespustí, pokud není proměnná nastavena.
 Pro ověření se používá HTTP Basic Auth nebo odeslání hesla v těle POST
 požadavku. Rozhraní umožňuje měnit API klíče i model a je určeno pouze
 pro interní použití. Příklad načtení konfigurace pomocí `curl`:

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,9 @@ from . import api_client, memory, knowledge
 app = Flask(__name__)
 
 # Password for admin interface
-ADMIN_PASS = os.environ.get('ADMIN_PASS', 'Kostal@2025')
+ADMIN_PASS = os.environ.get('ADMIN_PASS')
+if not ADMIN_PASS:
+    raise SystemExit('ADMIN_PASS environment variable is required')
 
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'config.json')
 


### PR DESCRIPTION
## Summary
- exit on startup if `ADMIN_PASS` is not set
- document setting `ADMIN_PASS` before running the server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68654c9e99408322862a68410fbade0b