### PR TITLE
Add category input to knowledge form

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -68,6 +68,7 @@ def ask():
 def add_knowledge():
     title = request.form.get('title')
     comment = request.form.get('comment', '')
+    category = request.form.get('category')
     text = request.form.get('text')
     file_obj = request.files.get('file')
     if not title:
@@ -75,7 +76,9 @@ def add_knowledge():
     if not text and file_obj is None:
         return jsonify({'error': 'Provide text or file'}), 400
     try:
-        knowledge.add_entry(title, comment, text=text, file=file_obj)
+        knowledge.add_entry(
+            title, comment, text=text, file=file_obj, category=category
+        )
         memory.log_knowledge_addition(title, comment)
     except Exception as exc:
         return jsonify({'error': str(exc)}), 500

--- a/static/ui.html
+++ b/static/ui.html
@@ -21,6 +21,7 @@
     <form id="knowledgeForm" enctype="multipart/form-data">
         Title: <input type="text" name="title"><br>
         Comment: <input type="text" name="comment"><br>
+        Category: <input type="text" name="category"><br>
         Text:<br>
         <textarea name="text" rows="4" cols="60"></textarea><br>
         File: <input type="file" name="file"><br>
@@ -48,6 +49,8 @@ document.getElementById('knowledgeForm').addEventListener('submit', async (e) =>
     e.preventDefault();
     const form = document.getElementById('knowledgeForm');
     const formData = new FormData(form);
+        const category = form.querySelector('input[name="category"]').value;
+    formData.append("category", category);
     const res = await fetch('/knowledge/add', {
         method: 'POST',
         body: formData


### PR DESCRIPTION
## Summary
- extend knowledge form with `category` field
- send category value in the upload request
- pass `category` to `knowledge.add_entry` on `/knowledge/add`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686658f92a4c8322806d0d7891573ab5