### PR TITLE
Extend context info from /ask

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -61,7 +61,15 @@ def ask():
         memory.save_interaction(user, message, response_text)
     except Exception:
         pass  # Ignore memory errors
-    return jsonify({'response': response_text, 'references': [e['title'] for e in related]})
+    refs = [
+        {
+            'title': e.get('title'),
+            'category': e.get('category'),
+            'comment': e.get('comment'),
+        }
+        for e in related
+    ]
+    return jsonify({'response': response_text, 'references': refs})
 
 
 @app.route('/knowledge/add', methods=['POST'])

--- a/static/ui.html
+++ b/static/ui.html
@@ -42,7 +42,12 @@ document.getElementById('askForm').addEventListener('submit', async (e) => {
     });
     const data = await res.json();
     document.getElementById('response').textContent = data.response || '';
-    document.getElementById('context').textContent = (data.references || []).join(', ');
+    const ctx = (data.references || []).map(r => {
+        const cat = r.category ? ` [${r.category}]` : '';
+        const comment = r.comment ? ` - ${r.comment}` : '';
+        return `${r.title}${cat}${comment}`;
+    }).join('\n');
+    document.getElementById('context').textContent = ctx;
 });
 
 document.getElementById('knowledgeForm').addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- include `category` and `comment` for every reference returned from `/ask`
- show the new reference fields in the web UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68665b01bcc88322bc339441d80f27bf