### PR TITLE
Improve Windows batch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,9 @@ Tento projekt je odlehčená verze Jarvika, navržená pro běh v prostředí be
 - `pip install flask langchain openai`
 
 ## Windows notes
-Scripts expect an executable named `python3`. If that command isn't available
-on Windows you can either add Python to your `PATH` or create an alias in your
-`~/.bashrc`:
-
-```bash
-alias python3='/c/Path/To/python.exe'
-```
-
-The startup scripts now try `python`, `python3` or `py` in this order, so as
-long as one of these commands exists the server will launch correctly.
+The batch scripts search for `python`, `python3` or `py` and use the first one
+found. Ensure at least one of these commands is available in your `PATH` so the
+server can start correctly.
 
 ## Creating a virtual environment
 To keep dependencies isolated you can create and activate a virtual environment:

--- a/scripts/update_instance.bat
+++ b/scripts/update_instance.bat
@@ -1,5 +1,20 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
+
+rem Detect available Python interpreter
+set "PYTHON="
+for %%P in (python python3 py) do (
+    where %%P >nul 2>&1 && (
+        set "PYTHON=%%P"
+        goto :found_python
+    )
+)
+echo Python interpreter not found.
+exit /b 1
+:found_python
+
+rem Use provided port or default to 5000
+if not defined PORT set PORT=5000
 
 rem Navigate to project root
 cd /d "%~dp0.."
@@ -9,8 +24,8 @@ if exist "venv\Scripts\activate.bat" (
     call "venv\Scripts\activate.bat"
 )
 
-rem Terminate any process using port 5000
-for /f "tokens=5" %%P in ('netstat -ano ^| findstr :5000') do (
+rem Terminate any process using the chosen port
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr :%PORT%') do (
     taskkill /F /PID %%P >nul 2>&1
 )
 
@@ -24,11 +39,11 @@ if exist memory (
 
 rem Update repository
 git pull
-pip install -r requirements.txt
+%PYTHON% -m pip install -r requirements.txt
 
 rem Restart the Flask server
 cd app
-python main.py > ..\flask.log 2>&1
+%PYTHON% main.py > ..\flask.log 2>&1
 cd ..
 
 endlocal

--- a/start.bat
+++ b/start.bat
@@ -1,5 +1,20 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
+
+rem Detect available Python interpreter
+set "PYTHON="
+for %%P in (python python3 py) do (
+    where %%P >nul 2>&1 && (
+        set "PYTHON=%%P"
+        goto :found_python
+    )
+)
+echo Python interpreter not found.
+exit /b 1
+:found_python
+
+rem Use provided port or default to 5000
+if not defined PORT set PORT=5000
 
 rem Ensure admin password is provided
 if not defined ADMIN_PASS (
@@ -15,14 +30,14 @@ if exist "venv\Scripts\activate.bat" (
     call "venv\Scripts\activate.bat"
 )
 
-rem Terminate any process using port 5000
-for /f "tokens=5" %%P in ('netstat -ano ^| findstr :5000') do (
+rem Terminate any process using the chosen port
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr :%PORT%') do (
     taskkill /F /PID %%P >nul 2>&1
 )
 
 rem Launch the Flask server
 cd app
-python main.py > ..\flask.log 2>&1
+%PYTHON% main.py > ..\flask.log 2>&1
 cd ..
 
 endlocal


### PR DESCRIPTION
## Summary
- detect `python`, `python3` or `py` in both batch scripts
- respect `%PORT%` when stopping/starting the server
- use `%PYTHON%` variable instead of hardcoding the command
- clarify README Windows notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3a27dd408327a2ef4c1bafee96a5