### PR TITLE
Set default port 80 and check privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ start.bat
 ```
 
 The batch file stops any process already listening on the port defined by
-the `PORT` variable (default `5000`) and runs the
+the `PORT` variable (default `80`) and runs the
 Flask app in the current window. Stop it with `Ctrl+C` or by closing the
 terminal. Run `start.bat` again or `scripts\update_instance.bat` to restart the
 server.
+Binding to ports below 1024 may require running the script as Administrator.
 For an update and automatic restart use `scripts\update_instance.bat`. It pulls
 the latest code, installs dependencies and then starts the server again.
 
@@ -74,7 +75,8 @@ python3 app/main.py
 
 ## 💻 Webové UI
 Po spuštění serveru otevři v prohlížeči `http://localhost:$PORT/`.
-Výchozí port je `5000` a lze jej změnit proměnnou prostředí `PORT`.
+Výchozí port je `80` a lze jej změnit proměnnou prostředí `PORT` (např. `PORT=443`).
+Při použití portů pod 1024 může být nutné spustit server s administrátorskými právy.
 Zobrazí se jednoduché rozhraní, kde zvolíš konfigurační profil,
 zadáš otázku a uvidíš odpověď i použitý kontext.
 V sekci "Add Knowledge" můžeš nahrát text nebo soubor s komentářem.

--- a/start.bat
+++ b/start.bat
@@ -13,8 +13,18 @@ echo Python interpreter not found.
 exit /b 1
 :found_python
 
-rem Use provided port or default to 5000
-if not defined PORT set PORT=5000
+rem Use provided port or default to 80
+if not defined PORT set PORT=80
+
+rem Require administrative privileges for ports under 1024
+for /f "tokens=1" %%A in ("%PORT%") do set PORT_NUM=%%A
+if %PORT_NUM% lss 1024 (
+    net session >nul 2>&1
+    if errorlevel 1 (
+        echo Insufficient privileges to bind to port %PORT_NUM%. Run as administrator or choose a higher port.
+        exit /b 1
+    )
+)
 
 rem Ensure admin password is provided
 if not defined ADMIN_PASS (

--- a/start.sh
+++ b/start.sh
@@ -14,9 +14,15 @@ if [ -z "$ADMIN_PASS" ]; then
     exit 1
 fi
 
-# Use provided port or default to 5000
-PORT=${PORT:-5000}
+# Use provided port or default to 80
+PORT=${PORT:-80}
 export PORT
+
+# Require root privileges for ports under 1024
+if [ "$PORT" -lt 1024 ] && [ "$(id -u)" -ne 0 ]; then
+    echo "Insufficient privileges to bind to port $PORT. Run as root or choose a higher port." >&2
+    exit 1
+fi
 
 # Determine the directory this script lives in and switch to the
 # repository root so relative paths work regardless of where the


### PR DESCRIPTION
## Summary
- use port 80 by default in both start scripts
- guard against running without the privileges required for ports under 1024
- document the new default port and how to switch to 443

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3c3eaad4832782744086f35689ac